### PR TITLE
create command full

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/alomia/fastman/pkg/fileutils"
+	"github.com/spf13/cobra"
+)
+
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new project, files, packages, or directories",
+	Long: `Create a new project, files, packages, or directories using Fastman.
+This command allows you to generate the necessary structure for your project, including files, Python packages, and directories.
+
+Examples:
+	fastman create -p mypackage
+	fastman create -f myfile.py
+	fastman create -d mydir
+	fastman create project [name-directory] --fastapi`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		packageName, _ := cmd.Flags().GetString("package")
+		fileName, _ := cmd.Flags().GetString("file")
+		dirName, _ := cmd.Flags().GetString("directory")
+
+		currentDir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		if packageName != "" {
+			packagePath := filepath.Join(currentDir, packageName)
+			err := fileutils.CreatePackage(packagePath)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Package %s created in: %s\n", packageName, currentDir)
+			return nil
+		}
+
+		if fileName != "" {
+			filePath := filepath.Join(currentDir, fileName)
+			err := fileutils.CreateFile(filePath)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("File %s created in: %s\n", fileName, currentDir)
+			return nil
+		}
+
+		if dirName != "" {
+			dirPath := filepath.Join(currentDir, dirName)
+			err := fileutils.CreateDirectory(dirPath)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Directory %s created in: %s\n", dirName, currentDir)
+			return nil
+		}
+
+		return cmd.Help()
+	},
+}
+
+func init() {
+	createCmd.Flags().StringP("package", "p", "", "Create a new Python package")
+	createCmd.Flags().StringP("file", "f", "", "Create a new file")
+	createCmd.Flags().StringP("directory", "d", "", "directory name")
+	rootCmd.AddCommand(createCmd)
+}

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/alomia/fastman/pkg/fileutils"
+	"github.com/alomia/fastman/pkg/projectmanager"
+	"github.com/spf13/cobra"
+)
+
+var projectCmd = &cobra.Command{
+	Use:   "project [directory-name]",
+	Short: "Create a new project",
+	Long: `Create a new project using Fastman. Currently, only FastAPI projects are supported.
+This command allows you to create a new project with a specific structure.
+
+Examples:
+	fastman create project myproject --fastapi`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fastapi, _ := cmd.Flags().GetBool("fastapi")
+
+		currentDir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		if fastapi {
+			if len(args) > 0 {
+				directory := args[0]
+				targetDir := filepath.Join(currentDir, directory)
+
+				err := fileutils.CreateDirectory(targetDir)
+				if err != nil {
+					return err
+				}
+
+				currentDir = targetDir
+			}
+
+			packages := []projectmanager.Package{
+				{
+					Name:  "models",
+					Files: []string{"products.py"},
+				},
+				{
+					Name:  "routes",
+					Files: []string{"products.py"},
+				},
+			}
+
+			files := []string{
+				"main.py",
+				"requirements.txt",
+			}
+
+			projectStruct := projectmanager.NewProjectStructure(
+				currentDir,
+				packages,
+				files,
+			)
+
+			err := projectStruct.CreateProjectStructure()
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("FastAPI project structure created in: %s\n", currentDir)
+			return nil
+		}
+
+		return cmd.Help()
+	},
+}
+
+func init() {
+	projectCmd.Flags().Bool("fastapi", false, "create a simple FastAPI project structure")
+	createCmd.AddCommand(projectCmd)
+}

--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/alomia/fastman/pkg/sampledata"
 )
 
 func CreateFile(path string, content ...[]byte) error {
@@ -54,6 +56,47 @@ func CreatePackage(path string) error {
 	initFilePath := filepath.Join(path, "__init__.py")
 	if err := CreateFile(initFilePath); err != nil {
 		return fmt.Errorf("error creating __init__.py file in package \"%s\": %w", namePackage, err)
+	}
+
+	return nil
+}
+
+func FileOrDirExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	return false, fmt.Errorf("error verifying the existence of the file or directory: %v", err)
+}
+
+func CreateConfigFile(currentDir string) error {
+	configFileName := "fastmanconf.yaml"
+	content, err := sampledata.GetSampleContent(configFileName)
+	if err != nil {
+		return err
+	}
+
+	configFilePath := filepath.Join(currentDir, configFileName)
+
+	exists, err := FileOrDirExists(configFilePath)
+	if err != nil {
+		return err
+	}
+
+	err = CreateFile(configFilePath, []byte(content))
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		fmt.Printf("fastman reset in: %s\n", currentDir)
+	} else {
+		fmt.Printf("fastman initialized in: %s\n", currentDir)
 	}
 
 	return nil

--- a/pkg/projectmanager/projectmanager.go
+++ b/pkg/projectmanager/projectmanager.go
@@ -27,6 +27,11 @@ func NewProjectStructure(path string, packages []Package, files []string) *Proje
 }
 
 func (p *ProjectStructure) CreateProjectStructure() error {
+	err := fileutils.CreateConfigFile(p.Path)
+	if err != nil {
+		return err
+	}
+
 	for _, pkg := range p.Packages {
 		pkgPath := filepath.Join(p.Path, pkg.Name)
 
@@ -37,8 +42,9 @@ func (p *ProjectStructure) CreateProjectStructure() error {
 
 		for _, file := range pkg.Files {
 			filePath := filepath.Join(pkgPath, file)
+			fileContentPath := filepath.Join(pkg.Name, file)
 
-			content, err := sampledata.GetSampleContent(filepath.Join(pkg.Name, file))
+			content, err := sampledata.GetSampleContent(fileContentPath)
 			if err != nil {
 				return err
 			}

--- a/pkg/sampledata/sampledata.go
+++ b/pkg/sampledata/sampledata.go
@@ -121,7 +121,7 @@ __pycache__/
 
 `
 
-var fileConfig = `packages:
+var fileFastmanconf = `packages:
   name:
     models:
       - products.py
@@ -134,7 +134,7 @@ var sampleContent = map[string]string{
 	"models/products.py": fileModelsProduct,
 	"routes/products.py": fileRoutesProduct,
 	"requirements.txt":   fileRequirements,
-	"config.yaml":        fileConfig,
+	"fastmanconf.yaml":   fileFastmanconf,
 }
 
 func GetSampleContent(fileName string) (string, error) {


### PR DESCRIPTION
# Fastman Create Command
The create command in Fastman allows you to create elements within your project. You can quickly create packages, files, and directories, helping you establish the basic structure of your project.

### Usage Examples:

1. Creating a package:
`fastman create --package mypackage`
This command creates a package named "mypackage" in the current directory.

2. Creating a file:
`fastman create --file myfile.txt`
This command creates a file named "myfile.txt" in the current directory.

3. Creating a directory:
This command creates a directory named "mydirectory" in the current directory.
`fastman create --directory mydirectory`

## Fastman Project Subcommand
The **project** subcommand allows you to create a new project using Fastman. Currently, it only supports the creation of FastAPI projects. You can specify the directory name where the project will be created and use the **--fastapi** flag to automatically create the FastAPI project structure.

### Usage Example:
`fastman create project myproject --fastapi`
This command creates a new FastAPI project named "myproject" in the current directory. The **--fastapi** flag indicates that the FastAPI project structure should be created.



