### PR TITLE
full run command

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alomia/fastman/pkg/executils"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// runCmd represents the run command
+var runCmd = &cobra.Command{
+	Use:   "run [script]",
+	Short: "Run a script",
+	Long: `Run a script specified by the provided script name.
+The script must be defined in the configuration file.
+
+Examples:
+  fastman run server`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		runScripts := viper.GetStringMapString("scripts.run")
+
+		if len(args) == 0 {
+			return cmd.Help()
+		}
+
+		script, ok := runScripts[args[0]]
+		if !ok {
+			return fmt.Errorf("%s script does not exist", args[0])
+		}
+
+		command := strings.Fields(script)
+		program := command[0]
+		arguments := command[1:]
+
+		err := executils.ExecuteCommand(program, arguments)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(runCmd)
+}

--- a/pkg/sampledata/sampledata.go
+++ b/pkg/sampledata/sampledata.go
@@ -130,6 +130,8 @@ scripts:
   install_from_file: python -m pip install -r {{package_file}}
   uninstall_package: python -m pip uninstall {{package_name}}
   uninstall_from_file: python -m pip uninstall -r {{package_file}}
+  run:
+    server: python -m main
 `
 
 var sampleContent = map[string]string{


### PR DESCRIPTION
## run command
The "run" command allows you to execute a script specified by its name. This script must be defined in the program's configuration file.
### Usage
`fastman run [script]`

Where "script" is the name of the script to be executed.

### Description
The "run" command executes a script specified by the provided name. The name of the script must be defined in the program's configuration file. If the script name does not exist in the configuration, an error will be displayed.

### Examples
`fastman run server`

This command will execute the script named "server" that is defined in the configuration file.

### Functionality

1. The "run" command retrieves the list of execution scripts from the program's configuration.
2. If no argument is provided, the command's help is displayed.
3. It checks if the specified script exists in the configuration.
4. If the script does not exist, an error is returned indicating that the script does not exist.
5. The script is split into a program and its arguments using spaces as separators.
6. The program is executed with the arguments using the `executils.ExecuteCommand` function from the `executils` package.
7. If any error occurs during execution, it is returned.
